### PR TITLE
Log extension-type statistics on search haystack refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "angelsharkd"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/angelsharkd/Cargo.toml
+++ b/angelsharkd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angelsharkd"
-version = "0.2.2"
+version = "0.2.3"
 edition = "2021"
 authors = ["Adam T. Carpenter <adam.carpenter@adp.com>"]
 description = "A HTTP interface into one or more Communication Managers"

--- a/angelsharkd/src/routes/extensions/mod.rs
+++ b/angelsharkd/src/routes/extensions/mod.rs
@@ -10,7 +10,7 @@ mod simple_search;
 
 /// The extension filter; consists of all compiled optional Angelshark extension
 /// filters combined under `/extensions`.
-pub fn filter(config: &Config) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
+pub fn filter(_config: &Config) -> impl Filter<Extract = impl Reply, Error = Rejection> + Clone {
     // Note: this next line deals with the common edge case of having no
     // extensions loaded with feature flags. It ensures that the the type
     // checking is right when the return `.and()` is called below.
@@ -19,20 +19,20 @@ pub fn filter(config: &Config) -> impl Filter<Extract = impl Reply, Error = Reje
     // Block to enable simple_search extension feature. Instantiates a
     // searchable haystack and configures filters to handle search requests.
     #[cfg(feature = "simple_search")]
-    let haystack = simple_search::Haystack::new(config.runner.clone());
+    let haystack = simple_search::Haystack::new(_config.runner.clone());
     #[cfg(feature = "simple_search")]
     let filters = filters
         .or(simple_search::search_filter(haystack.clone()))
         .or(simple_search::refresh_filter(haystack));
 
     #[cfg(feature = "simple_deprov")]
-    let filters = filters.or(simple_deprov::filter(config.runner.clone()));
+    let filters = filters.or(simple_deprov::filter(_config.runner.clone()));
 
     #[cfg(feature = "simple_busy")]
     let filters = filters
-        .or(simple_busy::busy_filter(config.runner.to_owned()))
-        .or(simple_busy::release_filter(config.runner.to_owned()))
-        .or(simple_busy::toggle_filter(config.runner.to_owned()));
+        .or(simple_busy::busy_filter(_config.runner.to_owned()))
+        .or(simple_busy::release_filter(_config.runner.to_owned()))
+        .or(simple_busy::toggle_filter(_config.runner.to_owned()));
 
     path("extensions").and(filters)
 }

--- a/angelsharkd/src/routes/extensions/simple_search/types.rs
+++ b/angelsharkd/src/routes/extensions/simple_search/types.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Context, Error};
 use libangelshark::{AcmRunner, Message, ParallelIterator};
-use log::error;
+use log::{error, info};
 use std::{
     collections::HashMap,
     env,
@@ -154,6 +154,18 @@ impl Haystack {
             })
             .flatten()
             .collect();
+
+        let ext_count = haystack.len();
+        let stat_count = haystack
+            .iter()
+            .filter(|e| e.get(1).map(String::as_str).unwrap_or_default() == "station-user")
+            .count();
+        let room_count = haystack
+            .iter()
+            .filter(|e| e.get(1).map(String::as_str).unwrap_or_default() == "station-user")
+            .filter(|e| !e.get(9).map(String::as_str).unwrap_or_default().is_empty())
+            .count();
+        info!("Downloaded {ext_count} fresh extension-types: {stat_count} station-users with {room_count} ROOMs.");
 
         // Overwrite shared haystack entries with new data.
         let mut lock = self


### PR DESCRIPTION
These stats may be used for capacity reporting purposes, but are also an indicator of memory and network usage, as well as refresh time for Angelshark.