### PR TITLE
feat: limit the number of search results with a query string parameter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "angelsharkd"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "anyhow",
  "env_logger",

--- a/angelsharkd/Cargo.toml
+++ b/angelsharkd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "angelsharkd"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["Adam T. Carpenter <adam.carpenter@adp.com>"]
 description = "A HTTP interface into one or more Communication Managers"

--- a/angelsharkd/src/routes/extensions/simple_search/README.md
+++ b/angelsharkd/src/routes/extensions/simple_search/README.md
@@ -72,6 +72,13 @@ POST /extensions/search
 ]
 ```
 
+To reduce network utilization and memory usage on the client side for broad
+search terms that yield many matches, users may limit the number of results
+returned with a query parameter. Pass `?limit=number` to limit the number of
+returned results. For example, to truncate all search results to the first 100
+entries, send `/extensions/search?limit=100`. _Angelshark does not guarantee the
+order of results._
+
 ## Logging
 
 The `refresh` endpoint always returns successfully. Any errors encountered

--- a/angelsharkd/src/routes/extensions/simple_search/types.rs
+++ b/angelsharkd/src/routes/extensions/simple_search/types.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Error};
 use libangelshark::{AcmRunner, Message, ParallelIterator};
 use log::{error, info};
+use serde::Deserialize;
 use std::{
     collections::HashMap,
     env,
@@ -12,6 +13,11 @@ const OSSI_STAT_NUMBER_FIELD: &str = "8005ff00";
 const OSSI_STAT_ROOM_FIELD: &str = "0031ff00";
 const OSSI_LIST_STAT_CMD: &str = "list station";
 const OSSI_LIST_EXT_CMD: &str = "list extension-type";
+
+#[derive(Deserialize)]
+pub struct Query {
+    pub limit: Option<usize>,
+}
 
 /// Collection of search terms
 pub type Needles = Vec<String>;


### PR DESCRIPTION
This patch adds the ability to limit the number of returned results from the search extension. This may be helpful for clients where broad search terms and large result sets may result in poor performance due to network utilization and memory usage. The limit is introduced in the form of a query string parameter, `?limit=100`. If no parameter is passed, all results are returned. Angelshark does not guarantee the order of results returned, and the first 100 results may differ from search to search.